### PR TITLE
Imagemagick should be optional

### DIFF
--- a/lib/sprite.coffee
+++ b/lib/sprite.coffee
@@ -21,7 +21,7 @@ class Sprite extends EventEmitter
           @emit "update"
 
   load: (cb = ->) ->
-    @_fromJson()
+    return cb(null) if true is @_fromJson()
     @_readImages (err, images) =>
       unless err
         @images = images
@@ -151,7 +151,7 @@ class Sprite extends EventEmitter
       info = fs.readFileSync @jsonUrl(), "UTF-8"
     catch error
       console.log @jsonUrl() + " not found"
-      return # no json file
+      return false # no json file
 
     info = JSON.parse info
     for img in info.images
@@ -164,5 +164,6 @@ class Sprite extends EventEmitter
       @images.push image
 
     @mapper.map @images
+    return true
 
 module.exports = Sprite


### PR DESCRIPTION
Alright, this is fairly small change, but possibly with bigger impact. I may be missing some other use cases that could be broken by this.

This change is made for the workflow when there are pure developers on the team and they don't want to install _garbage_ like Imagemagick to their machines. However they still need to be able to generate valid *.css files with attributes for sprites. That means only people working with graphics will generate sprites + json and commit to repository.
